### PR TITLE
chore: widen react-native peer range to 0.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "peerDependencies": {
     "react": ">=19.2.0 <20.0.0",
-    "react-native": ">=0.85.0 <0.86.0"
+    "react-native": ">=0.85.0 <0.87.0"
   },
   "workspaces": [
     "example"


### PR DESCRIPTION
Widens the `react-native` peer range to `>=0.85.0 <0.87.0` so the package installs cleanly under React Native 0.86.3 (Expo SDK 57). No code changes.